### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/Test/Corpus.pm
+++ b/lib/Test/Corpus.pm
@@ -1,4 +1,4 @@
-module Test::Corpus:auth<github:flussence>:ver<2.0.1>;
+unit module Test::Corpus:auth<github:flussence>:ver<2.0.1>;
 
 use Test;
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.